### PR TITLE
what-uses-libssl: find python3 w/ env

### DIFF
--- a/what-uses-libssl/make-dylib-graph.py
+++ b/what-uses-libssl/make-dylib-graph.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import json

--- a/what-uses-libssl/which-libssl-functions.py
+++ b/what-uses-libssl/which-libssl-functions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 import sys

--- a/what-uses-libssl/which-load-libssl.py
+++ b/what-uses-libssl/which-load-libssl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 


### PR DESCRIPTION
Small modifications to support non-standard python3 installs.